### PR TITLE
[Issue-324] Removes logic that parses registry host when using `kp cr…

### DIFF
--- a/pkg/commands/secret/create.go
+++ b/pkg/commands/secret/create.go
@@ -125,7 +125,7 @@ kp secret create my-git-cred --git-url https://github.com --git-user my-git-user
 				return err
 			}
 
-			return ch.PrintResult("Secret %q created", secret.Name)
+			return ch.PrintResult("Secret %q created for registry %s", secret.Name, target)
 		},
 	}
 

--- a/pkg/commands/secret/create.go
+++ b/pkg/commands/secret/create.go
@@ -125,7 +125,7 @@ kp secret create my-git-cred --git-url https://github.com --git-user my-git-user
 				return err
 			}
 
-			return ch.PrintResult("Secret %q created for registry %s", secret.Name, target)
+			return ch.PrintResult("Secret %q created for %s", secret.Name, target)
 		},
 	}
 

--- a/pkg/commands/secret/create_test.go
+++ b/pkg/commands/secret/create_test.go
@@ -96,7 +96,7 @@ func testSecretCreateCommand(t *testing.T, when spec.G, it spec.S) {
 				"--registry-user", registryUser,
 				"--service-account", "some-sa",
 				"-n", namespace},
-			ExpectedOutput: `Secret "my-registry-cred" created for registry my-registry.io
+			ExpectedOutput: `Secret "my-registry-cred" created for my-registry.io
 `,
 			ExpectCreates: []runtime.Object{
 				expectedRegistrySecret,
@@ -136,7 +136,7 @@ func testSecretCreateCommand(t *testing.T, when spec.G, it spec.S) {
 						defaultNamespacedServiceAccount,
 					},
 					Args: []string{secretName, "--dockerhub", dockerhubId, "-n", namespace},
-					ExpectedOutput: `Secret "my-docker-cred" created for registry https://index.docker.io/v1/
+					ExpectedOutput: `Secret "my-docker-cred" created for https://index.docker.io/v1/
 `,
 					ExpectCreates: []runtime.Object{
 						expectedDockerSecret,
@@ -176,7 +176,7 @@ func testSecretCreateCommand(t *testing.T, when spec.G, it spec.S) {
 						defaultNamespacedServiceAccount,
 					},
 					Args: []string{secretName, "--registry", registry, "--registry-user", registryUser, "-n", namespace},
-					ExpectedOutput: `Secret "my-registry-cred" created for registry https://index.docker.io/v1/
+					ExpectedOutput: `Secret "my-registry-cred" created for https://index.docker.io/v1/
 `,
 					ExpectCreates: []runtime.Object{
 						expectedDockerSecret,
@@ -216,7 +216,7 @@ func testSecretCreateCommand(t *testing.T, when spec.G, it spec.S) {
 						defaultNamespacedServiceAccount,
 					},
 					Args: []string{secretName, "--registry", registry, "--registry-user", registryUser, "-n", namespace},
-					ExpectedOutput: `Secret "my-registry-cred" created for registry my-registry.io
+					ExpectedOutput: `Secret "my-registry-cred" created for my-registry.io
 `,
 					ExpectCreates: []runtime.Object{
 						expectedDockerSecret,
@@ -254,7 +254,7 @@ func testSecretCreateCommand(t *testing.T, when spec.G, it spec.S) {
 						defaultNamespacedServiceAccount,
 					},
 					Args: []string{secretName, "--gcr", gcrServiceAccountFile, "-n", namespace},
-					ExpectedOutput: `Secret "my-gcr-cred" created for registry gcr.io
+					ExpectedOutput: `Secret "my-gcr-cred" created for gcr.io
 `,
 					ExpectCreates: []runtime.Object{
 						expectedDockerSecret,
@@ -295,7 +295,7 @@ func testSecretCreateCommand(t *testing.T, when spec.G, it spec.S) {
 						defaultNamespacedServiceAccount,
 					},
 					Args: []string{secretName, "--git-url", gitRepo, "--git-ssh-key", gitSshFile, "-n", namespace},
-					ExpectedOutput: `Secret "my-git-ssh-cred" created for registry git@github.com
+					ExpectedOutput: `Secret "my-git-ssh-cred" created for git@github.com
 `,
 					ExpectCreates: []runtime.Object{
 						expectedGitSecret,
@@ -338,7 +338,7 @@ func testSecretCreateCommand(t *testing.T, when spec.G, it spec.S) {
 						defaultNamespacedServiceAccount,
 					},
 					Args: []string{secretName, "--git-url", gitRepo, "--git-user", gitUser, "-n", namespace},
-					ExpectedOutput: `Secret "my-git-basic-cred" created for registry https://github.com
+					ExpectedOutput: `Secret "my-git-basic-cred" created for https://github.com
 `,
 					ExpectCreates: []runtime.Object{
 						expectedGitSecret,
@@ -379,7 +379,7 @@ func testSecretCreateCommand(t *testing.T, when spec.G, it spec.S) {
 						defaultServiceAccount,
 					},
 					Args: []string{secretName, "--dockerhub", dockerhubId},
-					ExpectedOutput: `Secret "my-docker-cred" created for registry https://index.docker.io/v1/
+					ExpectedOutput: `Secret "my-docker-cred" created for https://index.docker.io/v1/
 `,
 					ExpectCreates: []runtime.Object{
 						expectedDockerSecret,
@@ -419,7 +419,7 @@ func testSecretCreateCommand(t *testing.T, when spec.G, it spec.S) {
 						defaultServiceAccount,
 					},
 					Args: []string{secretName, "--registry", registry, "--registry-user", registryUser},
-					ExpectedOutput: `Secret "my-registry-cred" created for registry my-registry.io
+					ExpectedOutput: `Secret "my-registry-cred" created for my-registry.io
 `,
 					ExpectCreates: []runtime.Object{
 						expectedDockerSecret,
@@ -457,7 +457,7 @@ func testSecretCreateCommand(t *testing.T, when spec.G, it spec.S) {
 						defaultServiceAccount,
 					},
 					Args: []string{secretName, "--gcr", gcrServiceAccountFile},
-					ExpectedOutput: `Secret "my-gcr-cred" created for registry gcr.io
+					ExpectedOutput: `Secret "my-gcr-cred" created for gcr.io
 `,
 					ExpectCreates: []runtime.Object{
 						expectedDockerSecret,
@@ -498,7 +498,7 @@ func testSecretCreateCommand(t *testing.T, when spec.G, it spec.S) {
 						defaultServiceAccount,
 					},
 					Args: []string{secretName, "--git-url", gitRepo, "--git-ssh-key", gitSshFile},
-					ExpectedOutput: `Secret "my-git-ssh-cred" created for registry git@github.com
+					ExpectedOutput: `Secret "my-git-ssh-cred" created for git@github.com
 `,
 					ExpectCreates: []runtime.Object{
 						expectedGitSecret,
@@ -541,7 +541,7 @@ func testSecretCreateCommand(t *testing.T, when spec.G, it spec.S) {
 						defaultServiceAccount,
 					},
 					Args: []string{secretName, "--git-url", gitRepo, "--git-user", gitUser},
-					ExpectedOutput: `Secret "my-git-basic-cred" created for registry https://github.com
+					ExpectedOutput: `Secret "my-git-basic-cred" created for https://github.com
 `,
 					ExpectCreates: []runtime.Object{
 						expectedGitSecret,
@@ -690,7 +690,7 @@ secrets:
 					"--dockerhub", "my-dockerhub-id",
 					"--dry-run",
 				},
-				ExpectedOutput: `Secret "my-docker-cred" created for registry https://index.docker.io/v1/ (dry run)
+				ExpectedOutput: `Secret "my-docker-cred" created for https://index.docker.io/v1/ (dry run)
 `,
 			}.TestK8s(t, cmdFunc)
 		})

--- a/pkg/commands/secret/create_test.go
+++ b/pkg/commands/secret/create_test.go
@@ -96,7 +96,7 @@ func testSecretCreateCommand(t *testing.T, when spec.G, it spec.S) {
 				"--registry-user", registryUser,
 				"--service-account", "some-sa",
 				"-n", namespace},
-			ExpectedOutput: `Secret "my-registry-cred" created
+			ExpectedOutput: `Secret "my-registry-cred" created for registry my-registry.io
 `,
 			ExpectCreates: []runtime.Object{
 				expectedRegistrySecret,
@@ -136,7 +136,7 @@ func testSecretCreateCommand(t *testing.T, when spec.G, it spec.S) {
 						defaultNamespacedServiceAccount,
 					},
 					Args: []string{secretName, "--dockerhub", dockerhubId, "-n", namespace},
-					ExpectedOutput: `Secret "my-docker-cred" created
+					ExpectedOutput: `Secret "my-docker-cred" created for registry https://index.docker.io/v1/
 `,
 					ExpectCreates: []runtime.Object{
 						expectedDockerSecret,
@@ -176,7 +176,7 @@ func testSecretCreateCommand(t *testing.T, when spec.G, it spec.S) {
 						defaultNamespacedServiceAccount,
 					},
 					Args: []string{secretName, "--registry", registry, "--registry-user", registryUser, "-n", namespace},
-					ExpectedOutput: `Secret "my-registry-cred" created
+					ExpectedOutput: `Secret "my-registry-cred" created for registry https://index.docker.io/v1/
 `,
 					ExpectCreates: []runtime.Object{
 						expectedDockerSecret,
@@ -216,7 +216,7 @@ func testSecretCreateCommand(t *testing.T, when spec.G, it spec.S) {
 						defaultNamespacedServiceAccount,
 					},
 					Args: []string{secretName, "--registry", registry, "--registry-user", registryUser, "-n", namespace},
-					ExpectedOutput: `Secret "my-registry-cred" created
+					ExpectedOutput: `Secret "my-registry-cred" created for registry my-registry.io
 `,
 					ExpectCreates: []runtime.Object{
 						expectedDockerSecret,
@@ -254,7 +254,7 @@ func testSecretCreateCommand(t *testing.T, when spec.G, it spec.S) {
 						defaultNamespacedServiceAccount,
 					},
 					Args: []string{secretName, "--gcr", gcrServiceAccountFile, "-n", namespace},
-					ExpectedOutput: `Secret "my-gcr-cred" created
+					ExpectedOutput: `Secret "my-gcr-cred" created for registry gcr.io
 `,
 					ExpectCreates: []runtime.Object{
 						expectedDockerSecret,
@@ -295,7 +295,7 @@ func testSecretCreateCommand(t *testing.T, when spec.G, it spec.S) {
 						defaultNamespacedServiceAccount,
 					},
 					Args: []string{secretName, "--git-url", gitRepo, "--git-ssh-key", gitSshFile, "-n", namespace},
-					ExpectedOutput: `Secret "my-git-ssh-cred" created
+					ExpectedOutput: `Secret "my-git-ssh-cred" created for registry git@github.com
 `,
 					ExpectCreates: []runtime.Object{
 						expectedGitSecret,
@@ -338,7 +338,7 @@ func testSecretCreateCommand(t *testing.T, when spec.G, it spec.S) {
 						defaultNamespacedServiceAccount,
 					},
 					Args: []string{secretName, "--git-url", gitRepo, "--git-user", gitUser, "-n", namespace},
-					ExpectedOutput: `Secret "my-git-basic-cred" created
+					ExpectedOutput: `Secret "my-git-basic-cred" created for registry https://github.com
 `,
 					ExpectCreates: []runtime.Object{
 						expectedGitSecret,
@@ -379,7 +379,7 @@ func testSecretCreateCommand(t *testing.T, when spec.G, it spec.S) {
 						defaultServiceAccount,
 					},
 					Args: []string{secretName, "--dockerhub", dockerhubId},
-					ExpectedOutput: `Secret "my-docker-cred" created
+					ExpectedOutput: `Secret "my-docker-cred" created for registry https://index.docker.io/v1/
 `,
 					ExpectCreates: []runtime.Object{
 						expectedDockerSecret,
@@ -419,7 +419,7 @@ func testSecretCreateCommand(t *testing.T, when spec.G, it spec.S) {
 						defaultServiceAccount,
 					},
 					Args: []string{secretName, "--registry", registry, "--registry-user", registryUser},
-					ExpectedOutput: `Secret "my-registry-cred" created
+					ExpectedOutput: `Secret "my-registry-cred" created for registry my-registry.io
 `,
 					ExpectCreates: []runtime.Object{
 						expectedDockerSecret,
@@ -457,7 +457,7 @@ func testSecretCreateCommand(t *testing.T, when spec.G, it spec.S) {
 						defaultServiceAccount,
 					},
 					Args: []string{secretName, "--gcr", gcrServiceAccountFile},
-					ExpectedOutput: `Secret "my-gcr-cred" created
+					ExpectedOutput: `Secret "my-gcr-cred" created for registry gcr.io
 `,
 					ExpectCreates: []runtime.Object{
 						expectedDockerSecret,
@@ -498,7 +498,7 @@ func testSecretCreateCommand(t *testing.T, when spec.G, it spec.S) {
 						defaultServiceAccount,
 					},
 					Args: []string{secretName, "--git-url", gitRepo, "--git-ssh-key", gitSshFile},
-					ExpectedOutput: `Secret "my-git-ssh-cred" created
+					ExpectedOutput: `Secret "my-git-ssh-cred" created for registry git@github.com
 `,
 					ExpectCreates: []runtime.Object{
 						expectedGitSecret,
@@ -541,7 +541,7 @@ func testSecretCreateCommand(t *testing.T, when spec.G, it spec.S) {
 						defaultServiceAccount,
 					},
 					Args: []string{secretName, "--git-url", gitRepo, "--git-user", gitUser},
-					ExpectedOutput: `Secret "my-git-basic-cred" created
+					ExpectedOutput: `Secret "my-git-basic-cred" created for registry https://github.com
 `,
 					ExpectCreates: []runtime.Object{
 						expectedGitSecret,
@@ -690,7 +690,7 @@ secrets:
 					"--dockerhub", "my-dockerhub-id",
 					"--dry-run",
 				},
-				ExpectedOutput: `Secret "my-docker-cred" created (dry run)
+				ExpectedOutput: `Secret "my-docker-cred" created for registry https://index.docker.io/v1/ (dry run)
 `,
 			}.TestK8s(t, cmdFunc)
 		})

--- a/pkg/secret/factory.go
+++ b/pkg/secret/factory.go
@@ -198,7 +198,7 @@ func (f *Factory) makeRegistrySecret(secretName string, namespace string) (*core
 	registry := f.Registry
 	// Handle path in registry
 	if strings.ContainsRune(registry, '/') {
-		if strings.Contains(registry, "https://index.docker.io") {
+		if strings.Contains(registry, "index.docker.io") {
 			registry = DockerhubUrl
 		} else {
 			r, err := name.NewRepository(registry, name.WeakValidation)

--- a/pkg/secret/factory.go
+++ b/pkg/secret/factory.go
@@ -5,12 +5,11 @@ package secret
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"sort"
 	"strings"
 
 	"github.com/google/go-containerregistry/pkg/authn"
-	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -161,7 +160,7 @@ func (f *Factory) makeDockerhubSecret(name, namespace string) (*corev1.Secret, s
 }
 
 func (f *Factory) makeGcrSecret(name string, namespace string) (*corev1.Secret, string, error) {
-	password, err := ioutil.ReadFile(f.GcrServiceAccountFile)
+	password, err := os.ReadFile(f.GcrServiceAccountFile)
 	if err != nil {
 		return nil, "", err
 	}
@@ -196,14 +195,6 @@ func (f *Factory) makeRegistrySecret(secretName string, namespace string) (*core
 	}
 
 	reg := f.Registry
-	// Handle path in registry
-	if strings.ContainsRune(reg, '/') {
-		r, err := name.NewRepository(reg, name.WeakValidation)
-		if err != nil {
-			return nil, "", err
-		}
-		reg = r.RegistryStr()
-	}
 
 	configJson := DockerConfigJson{Auths: DockerCredentials{
 		reg: authn.AuthConfig{
@@ -229,7 +220,7 @@ func (f *Factory) makeRegistrySecret(secretName string, namespace string) (*core
 }
 
 func (f *Factory) makeGitSshSecret(name string, namespace string) (*corev1.Secret, string, error) {
-	password, err := ioutil.ReadFile(f.GitSshKeyFile)
+	password, err := os.ReadFile(f.GitSshKeyFile)
 	if err != nil {
 		return nil, "", err
 	}

--- a/pkg/secret/factory.go
+++ b/pkg/secret/factory.go
@@ -5,6 +5,7 @@ package secret
 
 import (
 	"encoding/json"
+	"github.com/google/go-containerregistry/pkg/name"
 	"os"
 	"sort"
 	"strings"
@@ -194,10 +195,22 @@ func (f *Factory) makeRegistrySecret(secretName string, namespace string) (*core
 		return nil, "", err
 	}
 
-	reg := f.Registry
+	registry := f.Registry
+	// Handle path in registry
+	if strings.ContainsRune(registry, '/') {
+		if strings.Contains(registry, "https://index.docker.io") {
+			registry = DockerhubUrl
+		} else {
+			r, err := name.NewRepository(registry, name.WeakValidation)
+			if err != nil {
+				return nil, "", err
+			}
+			registry = r.RegistryStr()
+		}
+	}
 
 	configJson := DockerConfigJson{Auths: DockerCredentials{
-		reg: authn.AuthConfig{
+		registry: authn.AuthConfig{
 			Username: f.RegistryUser,
 			Password: password,
 		},

--- a/pkg/secret/factory_test.go
+++ b/pkg/secret/factory_test.go
@@ -77,6 +77,16 @@ func testSecretFactory(t *testing.T, when spec.G, it spec.S) {
 		})
 	})
 
+	when("registry uses full path", func() {
+		it("uses only the registry domain", func() {
+			factory.Registry = "registry.io/my-repo"
+			factory.RegistryUser = "some-reg-user"
+			s, _, err := factory.MakeSecret("test-name", "test-namespace")
+			require.NoError(t, err)
+			require.Equal(t, `{"auths":{"registry.io":{"username":"some-reg-user","password":"foo","auth":"c29tZS1yZWctdXNlcjpmb28="}}}`, string(s.Data[".dockerconfigjson"]))
+		})
+	})
+
 	when("sub params are mixed with registry", func() {
 		it("returns an error message", func() {
 			factory.Registry = "some-registry"

--- a/pkg/secret/factory_test.go
+++ b/pkg/secret/factory_test.go
@@ -77,16 +77,6 @@ func testSecretFactory(t *testing.T, when spec.G, it spec.S) {
 		})
 	})
 
-	when("registry uses full path", func() {
-		it("uses only the registry domain", func() {
-			factory.Registry = "registry.io/my-repo"
-			factory.RegistryUser = "some-reg-user"
-			s, _, err := factory.MakeSecret("test-name", "test-namespace")
-			require.NoError(t, err)
-			require.Equal(t, `{"auths":{"registry.io":{"username":"some-reg-user","password":"foo","auth":"c29tZS1yZWctdXNlcjpmb28="}}}`, string(s.Data[".dockerconfigjson"]))
-		})
-	})
-
 	when("sub params are mixed with registry", func() {
 		it("returns an error message", func() {
 			factory.Registry = "some-registry"


### PR DESCRIPTION
…eate secret --registry` flag, fixes bug that caused dockerhub registry to parse incorrectly