### PR TITLE
[Issue 269] Print the build number on the console output after triggering the image build 

### DIFF
--- a/pkg/commands/image/trigger.go
+++ b/pkg/commands/image/trigger.go
@@ -67,9 +67,9 @@ The namespace defaults to the kubernetes current-context namespace.`,
 				if err != nil {
 					return err
 				}
-				build_id := builds.Labels["image.kpack.io/buildNumber"]
+				buildNumber := builds.Labels["image.kpack.io/buildNumber"]
 
-				_, err = fmt.Fprintf(cmd.OutOrStderr(), "Triggered build for Image Resource %q with Build ID %s\n", args[0],build_id)
+				_, err = fmt.Fprintf(cmd.OutOrStderr(), "Triggered build for Image Resource %q with Build Number %s\n", args[0],buildNumber)
 				return err
 			}
 		},

--- a/pkg/commands/image/trigger.go
+++ b/pkg/commands/image/trigger.go
@@ -67,9 +67,9 @@ The namespace defaults to the kubernetes current-context namespace.`,
 				if err != nil {
 					return err
 				}
-				buildNumber := builds.Labels["image.kpack.io/buildNumber"]
+				buildNumber := builds.Labels[v1alpha2.BuildNumberLabel]
 
-				_, err = fmt.Fprintf(cmd.OutOrStderr(), "Triggered build for Image Resource %q with Build Number %s\n", args[0],buildNumber)
+				_, err = fmt.Fprintf(cmd.OutOrStderr(), "Triggered build for Image Resource %q with Build Number %s\n", args[0], buildNumber)
 				return err
 			}
 		},

--- a/pkg/commands/image/trigger.go
+++ b/pkg/commands/image/trigger.go
@@ -63,12 +63,13 @@ The namespace defaults to the kubernetes current-context namespace.`,
 					return err
 				}
 
-				_, err = cs.KpackClient.KpackV1alpha2().Builds(cs.Namespace).Patch(ctx, original.Name, types.MergePatchType, patch, metav1.PatchOptions{})
+				builds, err := cs.KpackClient.KpackV1alpha2().Builds(cs.Namespace).Patch(ctx, original.Name, types.MergePatchType, patch, metav1.PatchOptions{})
 				if err != nil {
 					return err
 				}
+				build_id := builds.Labels["image.kpack.io/buildNumber"]
 
-				_, err = fmt.Fprintf(cmd.OutOrStderr(), "Triggered build for Image Resource %q\n", args[0])
+				_, err = fmt.Fprintf(cmd.OutOrStderr(), "Triggered build for Image Resource %q with Build ID %s\n", args[0],build_id)
 				return err
 			}
 		},

--- a/pkg/commands/image/trigger_test.go
+++ b/pkg/commands/image/trigger_test.go
@@ -42,7 +42,7 @@ func testImageTrigger(t *testing.T, when spec.G, it spec.S) {
 
 				err := cmd.Execute()
 				require.NoError(t, err)
-				require.Equal(t, "Triggered build for Image Resource \"some-image\"\n", out.String())
+				require.Equal(t, "Triggered build for Image Resource \"some-image\" with Build ID 3\n", out.String())
 
 				actions, err := testhelpers.ActionRecorderList{clientSet}.ActionsByVerb()
 				require.NoError(t, err)
@@ -87,7 +87,7 @@ func testImageTrigger(t *testing.T, when spec.G, it spec.S) {
 
 				err := cmd.Execute()
 				require.NoError(t, err)
-				require.Equal(t, "Triggered build for Image Resource \"some-image\"\n", out.String())
+				require.Equal(t, "Triggered build for Image Resource \"some-image\" with Build ID 3\n", out.String())
 
 				actions, err := testhelpers.ActionRecorderList{clientSet}.ActionsByVerb()
 				require.NoError(t, err)

--- a/pkg/commands/image/trigger_test.go
+++ b/pkg/commands/image/trigger_test.go
@@ -42,7 +42,7 @@ func testImageTrigger(t *testing.T, when spec.G, it spec.S) {
 
 				err := cmd.Execute()
 				require.NoError(t, err)
-				require.Equal(t, "Triggered build for Image Resource \"some-image\" with Build ID 3\n", out.String())
+				require.Equal(t, "Triggered build for Image Resource \"some-image\" with Build Number 3\n", out.String())
 
 				actions, err := testhelpers.ActionRecorderList{clientSet}.ActionsByVerb()
 				require.NoError(t, err)
@@ -87,7 +87,7 @@ func testImageTrigger(t *testing.T, when spec.G, it spec.S) {
 
 				err := cmd.Execute()
 				require.NoError(t, err)
-				require.Equal(t, "Triggered build for Image Resource \"some-image\" with Build ID 3\n", out.String())
+				require.Equal(t, "Triggered build for Image Resource \"some-image\" with Build Number 3\n", out.String())
 
 				actions, err := testhelpers.ActionRecorderList{clientSet}.ActionsByVerb()
 				require.NoError(t, err)


### PR DESCRIPTION
This pull request resolves Issue #269, printing the build number on the console output when we trigger the image build using the `kp trigger` command 