### PR TITLE
Bump go version to 1.20

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/kpack-cli
 
-go 1.18
+go 1.20
 
 require (
 	github.com/aryann/difflib v0.0.0-20170710044230-e206f873d14a


### PR DESCRIPTION
some of the new k8s 0.27 libraries require features introduced in 1.19 and 1.20