### PR TITLE
Print the next build number when triggering an image

### DIFF
--- a/pkg/commands/image/trigger.go
+++ b/pkg/commands/image/trigger.go
@@ -6,6 +6,7 @@ package image
 import (
 	"fmt"
 	"sort"
+	"strconv"
 	"time"
 
 	"github.com/pivotal/kpack/pkg/apis/build/v1alpha2"
@@ -63,13 +64,14 @@ The namespace defaults to the kubernetes current-context namespace.`,
 					return err
 				}
 
-				builds, err := cs.KpackClient.KpackV1alpha2().Builds(cs.Namespace).Patch(ctx, original.Name, types.MergePatchType, patch, metav1.PatchOptions{})
+				_, err = cs.KpackClient.KpackV1alpha2().Builds(cs.Namespace).Patch(ctx, original.Name, types.MergePatchType, patch, metav1.PatchOptions{})
 				if err != nil {
 					return err
 				}
-				buildNumber := builds.Labels[v1alpha2.BuildNumberLabel]
 
-				_, err = fmt.Fprintf(cmd.OutOrStderr(), "Triggered build for Image Resource %q with Build Number %s\n", args[0], buildNumber)
+				previousBuildNumber, _ := strconv.Atoi(patched.Labels[v1alpha2.BuildNumberLabel])
+
+				_, err = fmt.Fprintf(cmd.OutOrStderr(), "Triggered build for Image Resource %q with Build Number %d\n", args[0], previousBuildNumber+1)
 				return err
 			}
 		},

--- a/pkg/commands/image/trigger_test.go
+++ b/pkg/commands/image/trigger_test.go
@@ -42,7 +42,7 @@ func testImageTrigger(t *testing.T, when spec.G, it spec.S) {
 
 				err := cmd.Execute()
 				require.NoError(t, err)
-				require.Equal(t, "Triggered build for Image Resource \"some-image\" with Build Number 3\n", out.String())
+				require.Equal(t, "Triggered build for Image Resource \"some-image\" with Build Number 4\n", out.String())
 
 				actions, err := testhelpers.ActionRecorderList{clientSet}.ActionsByVerb()
 				require.NoError(t, err)
@@ -87,7 +87,7 @@ func testImageTrigger(t *testing.T, when spec.G, it spec.S) {
 
 				err := cmd.Execute()
 				require.NoError(t, err)
-				require.Equal(t, "Triggered build for Image Resource \"some-image\" with Build Number 3\n", out.String())
+				require.Equal(t, "Triggered build for Image Resource \"some-image\" with Build Number 4\n", out.String())
 
 				actions, err := testhelpers.ActionRecorderList{clientSet}.ActionsByVerb()
 				require.NoError(t, err)


### PR DESCRIPTION
- Since we patch the previous build, the number will be one less than expected

fixes #354