### PR TITLE
Add .exe extension back to windows binary

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,6 +79,8 @@ jobs:
         build linux arm64
         build windows amd64
 
+        mv kp-binaries/kp-windows-amd64-${{ env.VERSION }} kp-binaries/kp-windows-amd64-${{ env.VERSION }}.exe
+
     - name: Upload binaries
       uses: actions/upload-artifact@v3
       with:


### PR DESCRIPTION
This was a regression from when we migrated our build process to GHA